### PR TITLE
prependended xyz-cv-ui/ for the path of menu template

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -21,7 +21,7 @@
 
 <body resize>
 
-    <div data-ng-include="'layout/menu/menu.html'"></div>
+    <div data-ng-include="'/xyz-cv-ui/layout/menu/menu.html'"></div>
 
     <!-- inject:vendor:js -->
     <script src="angular/angular.js"></script>


### PR DESCRIPTION
The index file linked an include to layout/menu/menu.html; this was incorrect as that path is neither linked in the cache nor exists physically on the production server. 

The fix was to prepend the path with the project name (/xyz-cv-ui/), thus linking the cache to it.
