### PR TITLE
now correctly creates one user only upon first enter

### DIFF
--- a/src/app/components/menu/menu.controller.js
+++ b/src/app/components/menu/menu.controller.js
@@ -5,7 +5,7 @@
         .module('xyz-cv-ui.menu')
         .controller('MenuController', MenuController);
 
-        function MenuController(OfficesService, Users, Files, API_URL, $q) {
+        function MenuController(OfficesService, UsersService, Files, API_URL, $q, session) {
             var vm = this;
             vm.API_URL = API_URL;
             window.vm5 = vm;
@@ -17,13 +17,14 @@
             vm.panels = [];
             vm.panels.activePanel = [];
 
-            activate();
+            session.isLoaded()
+                .then(activate);
 
             //////////////
 
             function activate() {
                 var promises = {
-                    user: Users.get({ _id: 'current' }).$promise,
+                    user: UsersService.getCurrent(),
                     offices: OfficesService.get()
                 };
 

--- a/src/app/components/menu/menu.module.js
+++ b/src/app/components/menu/menu.module.js
@@ -5,7 +5,8 @@
     	'mgcrea.ngStrap',
 		'mgcrea.ngStrap.collapse',
         'shared.offices',
-        'shared.files'
+        'shared.files',
+        'shared.users'
     ]);
 
 })();

--- a/src/app/components/profile/modal/skills/skills.view.html
+++ b/src/app/components/profile/modal/skills/skills.view.html
@@ -8,14 +8,14 @@
 			<div class="modal-body">
 				<form class="form-horizontal">
 					<div class="form-group">
-						<label class="col-md-2 control-label">Name</label>
-						<div class="col-md-10">
+						<label class="col-md-3 control-label">Name</label>
+						<div class="col-md-9">
 							<input type="text" class="form-control" ng-model="vm.currentConnector.name" bs-options="skill.name as skill.name for skill in vm.skills" placeholder="Name" bs-typeahead>
 						</div>
 					</div>
 					<div class="form-group">
-						<label class="col-md-2 control-label">Experience</label>
-						<div class="col-md-10">
+						<label class="col-md-3 control-label">Experience</label>
+						<div class="col-md-9">
 							<div class="row">
 								<div class="col-md-6">
 									<div class="input-group">

--- a/src/app/components/profile/profile.controller.js
+++ b/src/app/components/profile/profile.controller.js
@@ -83,7 +83,8 @@
                 maxWeight: 1
             };
 
-            activate();
+            session.isLoaded()
+                .then(activate);
 
             //////////////
 

--- a/src/app/core/session/session.service.js
+++ b/src/app/core/session/session.service.js
@@ -5,20 +5,27 @@
         .module('core.session')
         .factory('session', session);
 
-    function session($rootScope, Authentication, $sessionStorage) {
+    function session($rootScope, Authentication, $sessionStorage, $q) {
 
         var sessionScope = $rootScope.$new(true);
         sessionScope.$storage = $sessionStorage;
-
+        var activated = $q.defer();
         var service = {
             isAllowed: isAllowed,
             canView: canView,
-            isSelf: isSelf
+            isSelf: isSelf,
+            isLoaded: isLoaded
         };
 
         if (!sessionExists()) {
             setUserPropertiesInSession();
+        } else {
+            activated.resolve();
         }
+
+        activated.promise.then(function() {
+            console.log('done')
+        })
 
         return service;
 
@@ -30,6 +37,7 @@
             getUserProperties().then(function(properties) {
                 sessionScope.$storage.userAttributes = properties.attributes;
                 sessionScope.$storage.userId = properties.userId;
+                activated.resolve();
             });
         }
 
@@ -63,7 +71,13 @@
         }
 
         function isSelf(id) {
+            console.log(sessionScope.$storage.userId);
             return (sessionScope.$storage.userId === id);
+        }
+
+        function isLoaded() {
+            console.log('returning a promise');
+            return activated.promise;
         }
     }
 })();

--- a/src/app/shared/users/users.service.js
+++ b/src/app/shared/users/users.service.js
@@ -1,0 +1,68 @@
+(function() {
+    'use strict';
+
+    angular
+        .module('shared.users')
+        .factory('UsersService', UsersService);
+
+    function UsersService(Users, $q, $timeout) {
+        var users = [];
+        var current = {};
+        var called = false;
+
+        var service = {
+            getUsers: getUsers,
+            getCurrent: getCurrent
+        };
+
+        return service;
+
+        /////////////////
+
+        function getUsers() {
+            return $q(function(resolve) {
+                if (users.length) {
+                    return resolve(users);
+                } else {
+                    waitIfCalled()
+                        .then(function() {
+                            Users.query().$promise
+                                .then(function(res) {
+                                    users = res;
+                                    return resolve(users);
+                                });
+                        });
+                }
+            });
+        }
+
+        function getCurrent() {
+            return $q(function(resolve) {
+                if (current._id) {
+                    return resolve(current);
+                } else {
+                    waitIfCalled()
+                        .then(function() {
+                            Users.get({_id: 'current'}).$promise
+                                .then(function(res) {
+                                    current = res;
+                                    return resolve(current);
+                                });
+                        })
+                }
+            });
+        }
+
+        function waitIfCalled() {
+            return $q(function(resolve) {
+                if (called) {
+                    $timeout(function() {
+                        return resolve();
+                    }, 150);
+                }
+                return resolve();
+            })
+        }
+    }
+
+})();


### PR DESCRIPTION
```
found a bug where the page made several requests at the same time to the api.
the user didn't exist so all of the requests went through createIfNonExisten;
thus yielding 3 users.

Solved the bug by letting the session service alone make the first call.
The rest of the controllers are listening for a promise to resolve once
the session has been activated.
```
